### PR TITLE
refactor(ssl): use default cipher suites

### DIFF
--- a/src/emqx_ct_helpers.erl
+++ b/src/emqx_ct_helpers.erl
@@ -46,8 +46,12 @@
         , render_config_file/2
         ]).
 
--define(CIPHERS, [{ciphers,
-                   ["ECDHE-ECDSA-AES256-GCM-SHA384",
+%% TODO: use default versions and cipers
+%% hard coded for now because it is used to override
+%% default config {cipers, undefined}
+-define(CIPHERS,
+        [{versions, ['tlsv1.1', 'tlsv1.2']},
+         {ciphers,  ["ECDHE-ECDSA-AES256-GCM-SHA384",
                     "ECDHE-RSA-AES256-GCM-SHA384",
                     "ECDHE-ECDSA-AES256-SHA384",
                     "ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-DES-CBC3-SHA",


### PR DESCRIPTION
Ensure tlsv1.1 and tlsv1.2 are configured explicitly to make it work on OTP-23 because on OTP-23, it defaults to tlsv1.3